### PR TITLE
issue-8 Reinstall libzip-dev

### DIFF
--- a/.docker/phpApache/Dockerfile
+++ b/.docker/phpApache/Dockerfile
@@ -2,7 +2,7 @@ ARG PHP_VERSION=""
 FROM php:${PHP_VERSION}-apache
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git zlib1g-dev zip unzip
+    && apt-get install -y --no-install-recommends git zlib1g-dev libzip-dev zip unzip
 
 RUN docker-php-ext-install pdo_mysql zip
 RUN pecl install xdebug \


### PR DESCRIPTION
It required because there was the following error: 'configure: error: Please reinstall the libzip distribution'